### PR TITLE
Added ability to paste in previous results and link to results.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,13 +16,29 @@
 
     <div class="container">
       <div class="row">
+
+    <div class="col-md-8 col-md-offset-2">
+      <button class="btn btn-link pull-right btn-small open-paste-tool-js">Paste in previous results...</button>
+      <div class="panel panel-default paste-tool">
+        <div class="panel-heading">
+          <h3 class="panel-title">Paste in your JSON data...</h3>
+        </div>
+        <div class="panel-body">
+          <div class="form-group">
+            <label class="control-label" for="paste-bucket">Paste JSON data</label>
+            <textarea class="form-control paste-bucket" id="paste-bucket" name="paste-bucket"></textarea>
+          </div>
+          <button class="btn btn-default">Apply</button>
+        </div>
+      </div>
+    </div>
         <div class="col-md-8 col-md-offset-2">
           <div class="jumbotron">
             <h1>JavaScript Project Checklist</h1>
             <p class="text-center">
               <a href="https://github.com/bitovi/checklist">The Github Repository</a> | <a href="http://blog.bitovi.com/why-checklist/">The Original Article</a></p>
-        </div>
-            
+          </div>
+  
       <div class="links panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title">Jump to section...</h3>

--- a/questions.json
+++ b/questions.json
@@ -1,298 +1,593 @@
 {
-  "heading": "JavaScript Project Checklist",
-  "questions": [{
-    "type": "text",
-    "label": "Project name"
-  }, {
-    "type": "text",
-    "label": "Company name"
-  }, {
-    "type": "single",
-    "label": "Was the project a success?",
-    "values": [ "Yes", "No", "Incomplete" ]
-  }, {
-    "type": "section",
-    "id": "management",
-    "label": "Management",
-    "questions": [{
-      "type": "section",
-      "label": "People know what they are trying to accomplish.",
-      "questions": [{
-        "type": "textarea",
-        "label": "What is the project's vision?",
-        "help": "This is typically a single sentence that describes what the project aspires to be.  Example: \"A JS framework that allows developers to build better apps, faster\". If this doesn't exist, write \"none\"."
-      }, {
-        "type": "textarea",
-        "label": "How will the project measure success?",
-        "help": "Example: Increase mobile conversion rates to 0.75-1.0%, currently ~0.3%. If this doesn't exist, write \"none\"."
-      }, {
-        "type": "textarea",
-        "label": "What is the strategy for accomplishing the project's goals?",
-        "help": "Example: Combine the desktop and mobile sites for an improved user experience, site parity, and centralized ownership. If this doesn't exist, write \"none\"."
-      }, {
-        "type": "textarea",
-        "label": "What is the project's roadmap?  What are the goals, plans and release schedule after the current release?",
-        "help": "Example: Phase 1: Complete A, B, C. Phase 2: Complete D, E, F.  If there are no plans, write \"none\"."
-      }, {
-        "type": "section",
-        "label": "People are capable of accomplishing the goals.",
-        "help": "Do people have the skills needed to accomplish the goals and roadmap?  Is the roadmap possible? Is there the access across the organizational bureaucracy?",
-        "questions": [{
-          "type": "single",
-          "label": "Do all employees go through a technical training?",
-          "help": "For example a week long JS training.",
-          "values": [ "Yes", "No" ]
-        }, {
-          "type": "single",
-          "label": "Is there at least one, yearly, additional training opportunity for all employees?",
-          "values": [ "Yes", "No" ]
-        }, {
-          "type": "single",
-          "label": "How long until something can be released?",
-          "values": [ "3 months", "6 months", "1 year", "1.5 years" ]
-        }, {
-          "type": "textarea",
-          "label": "What is the org chart?",
-          "help": "Each person's name and title. Indent subordinates under a manager. If this doesn't exist, write \"none\"."
-        }, {
-          "type": "textarea",
-          "label": "Who has the final say in content and copy decisions?",
-          "help": "A person's name. If multiple people, separate names with \";\"."
-        }, {
-          "type": "text",
-          "label": "Who has the final say in design decisions?",
-          "help": "A person's name. If multiple people, separate names with \";\"."
-        }, {
-          "type": "text",
-          "label": "Who has final say in technology and infrastructure decisions?",
-          "help": "The person's name. If multiple people, separate names with \";\"."
-        }, {
-          "type": "single",
-          "label": "Do product owners frequently (at least once a month) meet with:",
-          "values": [ "UX teams", "Dev teams" ]
-        }, {
-          "type": "single",
-          "label": "Have your company's values, experiences, and goals been expressed to management and the client team?",
-          "values": [ "Yes", "No" ]
-        }, {
-          "type": "single",
-          "label": "Has this checklist been reviewed with the management, design and development teams?",
-          "values": [ "Yes", "No" ]
-        }]
-      }]
-    }, {
-      "type": "section",
-      "label": "People like each other.",
-      "questions": [{
-        "type": "single",
-        "label": "Does the company have outings?",
-        "help": "Examples: dinners / activities outside work.",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "number",
-        "label": "How often, in months, do employee reviews happen?"
-      }]
-    }]
-  }, {
-    "type": "section",
-    "label": "Design & UX",
-    "id": "design",
-    "questions": [{
-      "type": "number",
-      "label": "How many designers on the project?"
-    }, {
-      "type": "section",
-      "label": "Informed",
-      "questions": [{
-        "type": "single",
-        "label": "Is user testing done?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "multi",
-        "label": "What user testing techniques are being used?",
-        "values": [ "Usability testing", "User interviews", "Surveys" ]
-      }, {
-        "type": "single",
-        "label": "Is analytic software being used?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Is AB testing being performed?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Are the results of user testing, analytics, and other data being discussed at least monthly?",
-        "values": [ "Yes", "No" ]
-      }]
-    }, {
-      "type": "section",
-      "label": "Quick Iterations",
-      "questions": [{
-        "type": "text",
-        "label": "How long, on average in weeks, between design changes and a user testing them?"
-      }, {
-        "type": "single",
-        "label": "Are design revisions factored into the estimate?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Are beta releases user tested?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Are prototypes and mockups user tested?",
-        "values": [ "Yes", "No" ]
-      }]
-    }, {
-      "type": "section",
-      "label": "Communication",
-      "questions": [{
-        "type": "multi",
-        "label": "The following documents are created with the client:",
-        "values": [ "Design guidelines / goals / statements", "Personas",
-          "User stories or use cases.", "Competitive analysis"]
-      }, {
-        "type": "multi",
-        "label": "The following documents are created:",
-        "values": [ "Wireframes and mockups", "Storyboards", "Prototypes",
-          "Prototypes", "High fidelity comps", "HTML prototypes",
-          "HTML style guide" ]
-      }, {
-        "type": "single",
-        "label": "Are videos or animations used to express interactions?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Are design issues and discussions \"publicly\" tracked?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "multi",
-        "label": "Where are design issues and discussions tracked?:",
-        "values": [ "Email", "Project management software (Trello, Basecamp)",
-          "Issue tracker (Jira / github)", "Excel" ]
-      }, {
-        "type": "single",
-        "label": "Does a design changelog exist?",
-        "help": "A design changelog is a document that contains a list of changes to the mockup/prototypes.",
-        "values": [ "Yes", "No" ]
-      }]
-    }]
-  }, {
-    "type": "section",
-    "id": "dev",
-    "label": "Development",
-    "help": "The following questions concern development specific problems.",
-    "questions": [{
-      "type": "section",
-      "label": "Tools and Environment",
-      "help": "The essential tools are in place and being used in the right way.",
-      "questions": [{
-        "type": "multi",
-        "label": "Source control is",
-        "values": [ "Used", "Git", "Used with a branch and merge strategy." ]
-      }, {
-        "type": "multi",
-        "label": "An issue tracker is",
-        "values": [ "Used", "Integrated with source control.", "Used by non developers." ]
-      }, {
-        "type": "multi",
-        "label": "The following environments exist",
-        "values": [ "Development", "Test", "Staging", "Production" ]
-      }, {
-        "type": "multi",
-        "label": "Continuous integration",
-        "values": [ "Exists", "Runs on all commits / pushes", "Emails on failure" ]
-      }, {
-        "type": "multi",
-        "label": "A 1-3 step process for the following exist:",
-        "values": [ "Setting up a development environment", "Testing the application.",
-          "Building the application into a production distributable.",
-          "Deploy to test and staging." ]
-      }]
-    }, {
-      "type": "section",
-      "label": "Code quality",
-      "help": "Practices and patterns that ensure good code.",
-      "questions": [{
-        "type": "single",
-        "label": "Is a module loader used?",
-        "help": "Examples: StealJS, RequireJS, Webpack, sprokets",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Is the high level architecture documented and followed?",
-        "help": "For example: MVVM plus a client state observable with specified properties.",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Are there unit tests?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Is there documentation for the code?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "multi",
-        "label": "All modules include:",
-        "values": [ "High level documentation.", "Tests", "Inline documentation", "A demo" ]
-      }, {
-        "type": "single",
-        "label": "Are there performance tests?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "multi",
-        "label": "The service layer is:",
-        "values": [ "RESTful", "Documented", "Tested", "Built / working" ]
-      }, {
-        "type": "single",
-        "label": "Is technical debt measured?",
-        "help": "Is some value (often in days / weeks) of technical debt calculated?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Is technical debt factored into estimates?",
-        "help": "Do estimations of time, or points, or effort include discussions of technical debt?",
-        "values": [ "Yes", "No" ]
-      }]
-    }, {
-      "type": "section",
-      "label": "Team",
-      "help": "Does the development team work well together.",
-      "questions": [{
-        "type": "single",
-        "label": "Is there a QA team or resource?",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Are teams grouped by specialty?",
-        "help": "Example: client vs server",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "number",
-        "label": "How many front-end developers?"
-      }, {
-        "type": "single",
-        "label": "Do you work alongside the client's developers?",
-        "help": "Your developers work on the same code as the client developers.",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "single",
-        "label": "Is every piece of code known to at least two people?",
-        "help": "No piece of code should be \"workable\" by only one person.",
-        "values": [ "Yes", "No" ]
-      }, {
-        "type": "multi",
-        "label": "There are code reviews",
-        "values": [ "Every commit", "Every week", "Every month", "Of new people's code", "Never" ]
-      }, {
-        "type": "textarea",
-        "label": "List examples of the client demonstrating the ability to add or change to new technology as needed.",
-        "help": "Examples: Adding memcache, moving to a cloud, setting up a CDN."
-      }, {
-        "type": "textarea",
-        "label": "List examples of needed changes in technology or process.",
-        "help": "Examples: Adding memcache, moving to a cloud, setting up a CDN."
-      }]
-    }]
-  }]
+    "heading": "JavaScript Project Checklist",
+    "questions": [
+        {
+            "type": "text",
+            "label": "Project name",
+            "name": "project-name"
+        },
+        {
+            "type": "text",
+            "label": "Company name",
+            "name": "company-name"
+        },
+        {
+            "type": "single",
+            "label": "Was the project a success?",
+            "values": [
+                "Yes",
+                "No",
+                "Incomplete"
+            ],
+            "name": "was-the-project-a-success"
+        },
+        {
+            "type": "section",
+            "id": "management",
+            "label": "Management",
+            "questions": [
+                {
+                    "type": "section",
+                    "label": "People know what they are trying to accomplish.",
+                    "questions": [
+                        {
+                            "type": "textarea",
+                            "label": "What is the project's vision?",
+                            "help": "This is typically a single sentence that describes what the project aspires to be.  Example: \"A JS framework that allows developers to build better apps, faster\". If this doesn't exist, write \"none\".",
+                            "name": "what-is-the-projects-vision"
+                        },
+                        {
+                            "type": "textarea",
+                            "label": "How will the project measure success?",
+                            "help": "Example: Increase mobile conversion rates to 0.75-1.0%, currently ~0.3%. If this doesn't exist, write \"none\".",
+                            "name": "how-will-the-project-measure-success"
+                        },
+                        {
+                            "type": "textarea",
+                            "label": "What is the strategy for accomplishing the project's goals?",
+                            "help": "Example: Combine the desktop and mobile sites for an improved user experience, site parity, and centralized ownership. If this doesn't exist, write \"none\".",
+                            "name": "what-is-the-strategy-for-accomplishing-t"
+                        },
+                        {
+                            "type": "textarea",
+                            "label": "What is the project's roadmap?  What are the goals, plans and release schedule after the current release?",
+                            "help": "Example: Phase 1: Complete A, B, C. Phase 2: Complete D, E, F.  If there are no plans, write \"none\".",
+                            "name": "what-is-the-projects-roadmap-what-are-th"
+                        },
+                        {
+                            "type": "section",
+                            "label": "People are capable of accomplishing the goals.",
+                            "help": "Do people have the skills needed to accomplish the goals and roadmap?  Is the roadmap possible? Is there the access across the organizational bureaucracy?",
+                            "questions": [
+                                {
+                                    "type": "single",
+                                    "label": "Do all employees go through a technical training?",
+                                    "help": "For example a week long JS training.",
+                                    "values": [
+                                        "Yes",
+                                        "No"
+                                    ],
+                                    "name": "do-all-employees-go-through-a-technical-"
+                                },
+                                {
+                                    "type": "single",
+                                    "label": "Is there at least one, yearly, additional training opportunity for all employees?",
+                                    "values": [
+                                        "Yes",
+                                        "No"
+                                    ],
+                                    "name": "is-there-at-least-one-yearly-additional-"
+                                },
+                                {
+                                    "type": "single",
+                                    "label": "How long until something can be released?",
+                                    "values": [
+                                        "3 months",
+                                        "6 months",
+                                        "1 year",
+                                        "1.5 years"
+                                    ],
+                                    "name": "how-long-until-something-can-be-released"
+                                },
+                                {
+                                    "type": "textarea",
+                                    "label": "What is the org chart?",
+                                    "help": "Each person's name and title. Indent subordinates under a manager. If this doesn't exist, write \"none\".",
+                                    "name": "what-is-the-org-chart"
+                                },
+                                {
+                                    "type": "textarea",
+                                    "label": "Who has the final say in content and copy decisions?",
+                                    "help": "A person's name. If multiple people, separate names with \";\".",
+                                    "name": "who-has-the-final-say-in-content-and-cop"
+                                },
+                                {
+                                    "type": "text",
+                                    "label": "Who has the final say in design decisions?",
+                                    "help": "A person's name. If multiple people, separate names with \";\".",
+                                    "name": "who-has-the-final-say-in-design-decision"
+                                },
+                                {
+                                    "type": "text",
+                                    "label": "Who has final say in technology and infrastructure decisions?",
+                                    "help": "The person's name. If multiple people, separate names with \";\".",
+                                    "name": "who-has-final-say-in-technology-and-infr"
+                                },
+                                {
+                                    "type": "single",
+                                    "label": "Do product owners frequently (at least once a month) meet with:",
+                                    "values": [
+                                        "UX teams",
+                                        "Dev teams"
+                                    ],
+                                    "name": "do-product-owners-frequently-at-least-on"
+                                },
+                                {
+                                    "type": "single",
+                                    "label": "Have your company's values, experiences, and goals been expressed to management and the client team?",
+                                    "values": [
+                                        "Yes",
+                                        "No"
+                                    ],
+                                    "name": "have-your-companys-values-experiences-an"
+                                },
+                                {
+                                    "type": "single",
+                                    "label": "Has this checklist been reviewed with the management, design and development teams?",
+                                    "values": [
+                                        "Yes",
+                                        "No"
+                                    ],
+                                    "name": "has-this-checklist-been-reviewed-with-th"
+                                }
+                            ],
+                            "name": "people-are-capable-of-accomplishing-the-"
+                        }
+                    ],
+                    "name": "people-know-what-they-are-trying-to-acco"
+                },
+                {
+                    "type": "section",
+                    "label": "People like each other.",
+                    "questions": [
+                        {
+                            "type": "single",
+                            "label": "Does the company have outings?",
+                            "help": "Examples: dinners / activities outside work.",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "does-the-company-have-outings"
+                        },
+                        {
+                            "type": "number",
+                            "label": "How often, in months, do employee reviews happen?",
+                            "name": "how-often-in-months-do-employee-reviews-"
+                        }
+                    ],
+                    "name": "people-like-each-other"
+                }
+            ],
+            "name": "management"
+        },
+        {
+            "type": "section",
+            "label": "Design & UX",
+            "id": "design",
+            "questions": [
+                {
+                    "type": "number",
+                    "label": "How many designers on the project?",
+                    "name": "how-many-designers-on-the-project"
+                },
+                {
+                    "type": "section",
+                    "label": "Informed",
+                    "questions": [
+                        {
+                            "type": "single",
+                            "label": "Is user testing done?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-user-testing-done"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "What user testing techniques are being used?",
+                            "values": [
+                                "Usability testing",
+                                "User interviews",
+                                "Surveys"
+                            ],
+                            "name": "what-user-testing-techniques-are-being-u"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Is analytic software being used?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-analytic-software-being-used"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Is AB testing being performed?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-ab-testing-being-performed"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are the results of user testing, analytics, and other data being discussed at least monthly?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-the-results-of-user-testing-analytic"
+                        }
+                    ],
+                    "name": "informed"
+                },
+                {
+                    "type": "section",
+                    "label": "Quick Iterations",
+                    "questions": [
+                        {
+                            "type": "text",
+                            "label": "How long, on average in weeks, between design changes and a user testing them?",
+                            "name": "how-long-on-average-in-weeks-between-des"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are design revisions factored into the estimate?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-design-revisions-factored-into-the-e"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are beta releases user tested?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-beta-releases-user-tested"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are prototypes and mockups user tested?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-prototypes-and-mockups-user-tested"
+                        }
+                    ],
+                    "name": "quick-iterations"
+                },
+                {
+                    "type": "section",
+                    "label": "Communication",
+                    "questions": [
+                        {
+                            "type": "multi",
+                            "label": "The following documents are created with the client:",
+                            "values": [
+                                "Design guidelines / goals / statements",
+                                "Personas",
+                                "User stories or use cases.",
+                                "Competitive analysis"
+                            ],
+                            "name": "the-following-documents-are-created-with"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "The following documents are created:",
+                            "values": [
+                                "Wireframes and mockups",
+                                "Storyboards",
+                                "Prototypes",
+                                "Prototypes",
+                                "High fidelity comps",
+                                "HTML prototypes",
+                                "HTML style guide"
+                            ],
+                            "name": "the-following-documents-are-created"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are videos or animations used to express interactions?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-videos-or-animations-used-to-express"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are design issues and discussions \"publicly\" tracked?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-design-issues-and-discussions-public"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "Where are design issues and discussions tracked?:",
+                            "values": [
+                                "Email",
+                                "Project management software (Trello, Basecamp)",
+                                "Issue tracker (Jira / github)",
+                                "Excel"
+                            ],
+                            "name": "where-are-design-issues-and-discussions-"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Does a design changelog exist?",
+                            "help": "A design changelog is a document that contains a list of changes to the mockup/prototypes.",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "does-a-design-changelog-exist"
+                        }
+                    ],
+                    "name": "communication"
+                }
+            ],
+            "name": "design--ux"
+        },
+        {
+            "type": "section",
+            "id": "dev",
+            "label": "Development",
+            "help": "The following questions concern development specific problems.",
+            "questions": [
+                {
+                    "type": "section",
+                    "label": "Tools and Environment",
+                    "help": "The essential tools are in place and being used in the right way.",
+                    "questions": [
+                        {
+                            "type": "multi",
+                            "label": "Source control is",
+                            "values": [
+                                "Used",
+                                "Git",
+                                "Used with a branch and merge strategy."
+                            ],
+                            "name": "source-control-is"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "An issue tracker is",
+                            "values": [
+                                "Used",
+                                "Integrated with source control.",
+                                "Used by non developers."
+                            ],
+                            "name": "an-issue-tracker-is"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "The following environments exist",
+                            "values": [
+                                "Development",
+                                "Test",
+                                "Staging",
+                                "Production"
+                            ],
+                            "name": "the-following-environments-exist"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "Continuous integration",
+                            "values": [
+                                "Exists",
+                                "Runs on all commits / pushes",
+                                "Emails on failure"
+                            ],
+                            "name": "continuous-integration"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "A 1-3 step process for the following exist:",
+                            "values": [
+                                "Setting up a development environment",
+                                "Testing the application.",
+                                "Building the application into a production distributable.",
+                                "Deploy to test and staging."
+                            ],
+                            "name": "a--step-process-for-the-following-exist"
+                        }
+                    ],
+                    "name": "tools-and-environment"
+                },
+                {
+                    "type": "section",
+                    "label": "Code quality",
+                    "help": "Practices and patterns that ensure good code.",
+                    "questions": [
+                        {
+                            "type": "single",
+                            "label": "Is a module loader used?",
+                            "help": "Examples: StealJS, RequireJS, Webpack, sprokets",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-a-module-loader-used"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Is the high level architecture documented and followed?",
+                            "help": "For example: MVVM plus a client state observable with specified properties.",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-the-high-level-architecture-documente"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are there unit tests?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-there-unit-tests"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Is there documentation for the code?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-there-documentation-for-the-code"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "All modules include:",
+                            "values": [
+                                "High level documentation.",
+                                "Tests",
+                                "Inline documentation",
+                                "A demo"
+                            ],
+                            "name": "all-modules-include"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are there performance tests?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-there-performance-tests"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "The service layer is:",
+                            "values": [
+                                "RESTful",
+                                "Documented",
+                                "Tested",
+                                "Built / working"
+                            ],
+                            "name": "the-service-layer-is"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Is technical debt measured?",
+                            "help": "Is some value (often in days / weeks) of technical debt calculated?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-technical-debt-measured"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Is technical debt factored into estimates?",
+                            "help": "Do estimations of time, or points, or effort include discussions of technical debt?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-technical-debt-factored-into-estimate"
+                        }
+                    ],
+                    "name": "code-quality"
+                },
+                {
+                    "type": "section",
+                    "label": "Team",
+                    "help": "Does the development team work well together.",
+                    "questions": [
+                        {
+                            "type": "single",
+                            "label": "Is there a QA team or resource?",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-there-a-qa-team-or-resource"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Are teams grouped by specialty?",
+                            "help": "Example: client vs server",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "are-teams-grouped-by-specialty"
+                        },
+                        {
+                            "type": "number",
+                            "label": "How many front-end developers?",
+                            "name": "how-many-frontend-developers"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Do you work alongside the client's developers?",
+                            "help": "Your developers work on the same code as the client developers.",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "do-you-work-alongside-the-clients-develo"
+                        },
+                        {
+                            "type": "single",
+                            "label": "Is every piece of code known to at least two people?",
+                            "help": "No piece of code should be \"workable\" by only one person.",
+                            "values": [
+                                "Yes",
+                                "No"
+                            ],
+                            "name": "is-every-piece-of-code-known-to-at-least"
+                        },
+                        {
+                            "type": "multi",
+                            "label": "There are code reviews",
+                            "values": [
+                                "Every commit",
+                                "Every week",
+                                "Every month",
+                                "Of new people's code",
+                                "Never"
+                            ],
+                            "name": "there-are-code-reviews"
+                        },
+                        {
+                            "type": "textarea",
+                            "label": "List examples of the client demonstrating the ability to add or change to new technology as needed.",
+                            "help": "Examples: Adding memcache, moving to a cloud, setting up a CDN.",
+                            "name": "list-examples-of-the-client-demonstratin"
+                        },
+                        {
+                            "type": "textarea",
+                            "label": "List examples of needed changes in technology or process.",
+                            "help": "Examples: Adding memcache, moving to a cloud, setting up a CDN.",
+                            "name": "list-examples-of-needed-changes-in-techn"
+                        }
+                    ],
+                    "name": "team"
+                }
+            ],
+            "name": "development"
+        }
+    ]
 }

--- a/resources/converter.js
+++ b/resources/converter.js
@@ -9,7 +9,7 @@ $(function() {
         caption: getLabel(current),
         type: name,
         options: {},
-        name: current.label
+        name: current.name ? current.name : current.label,
       };
       $.each(current.values, function(index, value) {
         dform.options[value] = value;
@@ -25,7 +25,7 @@ $(function() {
         html: {
           caption: getLabel(current),
           type: current.type,
-          name: current.label,
+          name: current.name ? current.name : current.label,
           class: 'form-control'
         }
       };
@@ -34,7 +34,7 @@ $(function() {
       var dform = {
         caption: getLabel(current),
         type: 'fieldset',
-        name: current.label,
+        name: current.name ? current.name : current.label,
         id: current.id,
         html: []
       };
@@ -53,6 +53,80 @@ $(function() {
     converter = converter || converters.default;
     return converter(data, depth ? depth + 1 : 0);
   };
+  
+  var PasteBucket = function () {
+    var pasteBucket = {
+      visible: false,
+      toggle: function (force) {
+        if (typeof force !== 'undefined') {
+          this.visible = force;
+        } else {
+          this.visible = !this.visible;
+        }
+        
+        if (this.visible) {
+          $('.paste-tool').show();
+        } else {
+          $('.paste-tool').hide();
+        }
+      },
+      processData: function () {
+        var pasteData = $('.paste-tool .paste-bucket').val(),
+            self = this;
+
+        if (pasteData.length === 0) {
+          $('.paste-bucket').parent('.form-group').addClass('has-error');
+          return false;
+        }
+        self.loadDataFromString(pasteData);
+        self.toggle();
+      },
+      checkParams: function () {
+        
+        var searchTerms = new can.List(window.location.search.replace('?','').split('&')),
+          pastedLink;
+        searchTerms.each(function (item) {
+          var params = item.split('=');
+          if (params[0] === 'checklist' && params[1]) {
+            pastedLink = decodeURI(params[1]);
+          }
+        });
+        
+        if (pastedLink) {
+          this.loadDataFromString(pastedLink);
+        }
+      },
+      loadDataFromString: function (dataString) {
+        var pasteDataMap = new can.Map(JSON.parse(dataString))
+        pasteDataMap.each(function (val, key, item) {
+            var $target = can.$('[name='+key+']');
+            if ($target.eq(0).is('[type=checkbox]')) {
+                val.each(function (chkboxVal) {
+                    $target.filter('[value="'+chkboxVal+'"]').prop('checked', true);
+                });
+                
+                return true;
+            }
+            if ($target.eq(0).is('[type=radio]')) {
+                $target.filter('[value="'+val+'"]').prop('checked', true);
+                return true;
+            }
+            $target.val(val);
+            
+        });
+      }
+    }
+    return pasteBucket;
+  }
+  var pasteBucket = new PasteBucket();
+    
+  $('.paste-tool .btn-default').on('click', function () {
+    pasteBucket.processData();
+  });
+  pasteBucket.toggle(false);//close the bucket
+  $('.open-paste-tool-js').on('click', function () {
+    pasteBucket.toggle();
+  });
 
   $.getJSON('questions.json').then(function(data) {
     var questions = data.questions;
@@ -72,6 +146,9 @@ $(function() {
     });
 
     $('#checklist').append("<div class='text-center'><input class='btn btn-lg btn-primary' type='submit' value='Submit' /></div>");
+    
+    //check if linking into results
+    pasteBucket.checkParams();
   });
 
   $('body').on('submit', 'form', function(ev){
@@ -81,17 +158,17 @@ $(function() {
   })
 
   var answers = {
-    "Do all employees go through a technical training?": 0.46,
-    "What is the project\'s vision?": 0.45,
-    "How long until something can be released?": 0.48,
-    "Does the company have outings?": 0.45,
-    "Is user testing done?": 0.45,
-    "The following documents are created:": 0.44,
-    "There are code reviews": 0.28,
-    "Are there unit tests?": 0.2,
-    "Is there documentation for the code?": 0.28,
-    "Continuous integration": 0.2,
-    "The following environments exist": 0.2
+    "do-all-employees-go-through-a-technical-": 0.46,//Do all employees go through a technical training?
+    "what-is-the-projects-vision": 0.45,//What is the project\'s vision?
+    "how-long-until-something-can-be-released": 0.48,//How long until something can be released?
+    "does-the-company-have-outings": 0.45,//Does the company have outings?
+    "is-user-testing-done": 0.45,//Is user testing done?
+    "the-following-documents-are-created": 0.44,//The following documents are created:
+    "there-are-code-reviews": 0.28,//There are code reviews
+    "are-there-unit-tests": 0.2,//Are there unit tests?
+    "is-there-documentation-for-the-code": 0.28,//Is there documentation for the code?
+    "continuous-integration": 0.2,//Continuous integration
+    "the-following-environments-exist": 0.2//The following environments exist
   }
 
   var getScore = function(data){


### PR DESCRIPTION
![checlist](https://cloud.githubusercontent.com/assets/2633542/8074488/398cff98-0f01-11e5-875e-a34632b2741f.gif)

Using the paste area, one could easily paste in results from a previous run through of the checklist. To further edit or share.

Even better, for sharing, using `http://bitovi.github.io/checklist/?checklist={blahblahblah}`. Obviously, if the link is too long this won't work but it's something.
